### PR TITLE
Correct the permission check

### DIFF
--- a/deploy-zimbra-letsencrypt.sh
+++ b/deploy-zimbra-letsencrypt.sh
@@ -92,7 +92,7 @@ fi
 #   exit 1
 #fi
 #
-/bin/cp -rf $user/.acme.sh .
+/bin/cp -rf $user/.acme.sh/$domain $certs
 if [ $? == 1 ]; then
    say "Check permissions: CERT cp failed for $user/.acme.sh"
 fi


### PR DESCRIPTION
If I understand correctly, the permission that is needed is for `$user/.acme.sh/$domain` to be able to be copied to `$certs`.  This pull request makes that change in the script.

At any rate `/bin/cp -rf $user/.acme.sh/ .` should be avoided since the result for  will be different depending on which directory the `zimbra` user runs `/opt/letsencrypt/deploy-zimbra-letsencrypt.sh` from.